### PR TITLE
changing ZT interface MTU back to 2800 and adding MSS clamping rules at 1300 bytes …

### DIFF
--- a/group_vars/baremetal_hosts/zerotier.yml
+++ b/group_vars/baremetal_hosts/zerotier.yml
@@ -1,6 +1,6 @@
 zt_subnet:
-    target: '10.55.0.0/24'
-zt_mtu: 1400
+  target: "10.55.0.0/24"
+zt_mtu: 2800
 zt:
   peer_group_name: zt
   peers:
@@ -19,3 +19,4 @@ zt:
     - name: p43
       ip: 10.55.0.43
       bgp_peer_as: 43
+zt_interface: "{{ ansible_interfaces | select('match','zt.*') | list | first }}"

--- a/roles/firewall/templates/baremetal_hosts/ufw_before_rules.j2
+++ b/roles/firewall/templates/baremetal_hosts/ufw_before_rules.j2
@@ -20,6 +20,7 @@
 COMMIT
 
 *mangle
+# cake QoS rules for plex video
 -A PREROUTING -p tcp -m multiport --dport 32400 -j DSCP --set-dscp-class AF41
 -A PREROUTING -p tcp -m multiport --sport 32400 -j DSCP --set-dscp-class AF41
 -A PREROUTING -p tcp -m multiport --dport 49152 -j DSCP --set-dscp-class CS1
@@ -47,6 +48,11 @@ COMMIT
 # Don't delete these required lines, otherwise there will be errors
 
 *filter
+# mss clamping rules to clamp to 1300 for ZT VPN traffic
+-A FORWARD -o {{ zt_interface }} -p tcp -m tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
+-A FORWARD -i {{ zt_interface }} -p tcp -m tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
+-A FORWARD -o {{ zt_interface }} -p tcp -m tcp --tcp-flags SYN,RST SYN -m tcpmss --mss 1301:65535 -j TCPMSS --set-mss 1300
+-A FORWARD -i {{ zt_interface }} -p tcp -m tcp --tcp-flags SYN,RST SYN -m tcpmss --mss 1301:65535 -j TCPMSS --set-mss 1300
 :ufw-before-input - [0:0]
 :ufw-before-output - [0:0]
 :ufw-before-forward - [0:0]


### PR DESCRIPTION
1300 bytes MSS Clamping in iptables
Was having issues with syncoid (zfs send) over the WAN, data input/output fails and corruption.  MSS clamping seems to have solved it so adding to the firewalls role.
…to UFW / IPtables to allow for more reliable ZFS sends and large file sends over the VPN/WAN